### PR TITLE
Fix rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,8 @@ AllCops:
     - 'bin/**/*'
     - 'tmp/**/*'
 
-require:
-  - rubocop-rspec
-
 plugins:
+  - rubocop-rspec
   - rubocop-rake
 
 Style/StringLiterals:
@@ -37,61 +35,7 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Max: 5
 
-# Disable external plugin namespaces we are not using to avoid warnings/crashes
-Capybara:
-  Enabled: false
-FactoryBot:
-  Enabled: false
-RSpecRails:
-  Enabled: false
 
-# Disable all Capybara cops to avoid warnings
-Capybara/CurrentPathExpectation:
-  Enabled: false
-Capybara/MatchStyle:
-  Enabled: false
-Capybara/NegationMatcher:
-  Enabled: false
-Capybara/SpecificActions:
-  Enabled: false
-Capybara/SpecificFinders:
-  Enabled: false
-Capybara/SpecificMatcher:
-  Enabled: false
-Capybara/VisibilityMatcher:
-  Enabled: false
-Capybara/RSpec/PredicateMatcher:
-  Enabled: false
-
-# Disable all FactoryBot cops to avoid warnings
-FactoryBot/AttributeDefinedStatically:
-  Enabled: false
-FactoryBot/ConsistentParenthesesStyle:
-  Enabled: false
-FactoryBot/CreateList:
-  Enabled: false
-FactoryBot/FactoryClassName:
-  Enabled: false
-FactoryBot/FactoryNameStyle:
-  Enabled: false
-FactoryBot/SyntaxMethods:
-  Enabled: false
-
-# Disable all RSpecRails cops to avoid warnings
-RSpecRails/AvoidSetupHook:
-  Enabled: false
-RSpecRails/HaveHttpStatus:
-  Enabled: false
-RSpecRails/HttpStatus:
-  Enabled: false
-RSpecRails/InferredSpecType:
-  Enabled: false
-RSpecRails/MinitestAssertions:
-  Enabled: false
-RSpecRails/NegationBeValid:
-  Enabled: false
-RSpecRails/TravelAround:
-  Enabled: false
 
 # Disable index-related warnings for biblical references (chapter:verse format is natural)
 RSpec/IndexedLet:


### PR DESCRIPTION
## Summary

This PR fixes the rubocop configuration issues that were preventing rubocop from running correctly.

## Changes Made

- ✅ Replace deprecated `require: rubocop-rspec` with `plugins: rubocop-rspec`
- ✅ Remove unrecognized cop configurations for Capybara, FactoryBot, and RSpecRails
- ✅ Clean up `.rubocop.yml` to only include relevant cops for this project

## Testing

- ✅ All 184 tests passing
- ✅ No rubocop offenses detected
- ✅ Full rake task (tests + rubocop) passes successfully

## Before

```
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec`
Error: unrecognized cop or department Capybara found in .rubocop.yml
unrecognized cop or department FactoryBot found in .rubocop.yml
...
```

## After

```
Inspecting 19 files
...................

19 files inspected, no offenses detected
```

This resolves the rubocop installation and configuration issues, ensuring proper code quality checks are in place.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author